### PR TITLE
Preload next hero image on home page.

### DIFF
--- a/src/pages/Home/script.js
+++ b/src/pages/Home/script.js
@@ -20,13 +20,19 @@ export default {
   computed: {
     heroImage () {
       return require(`./images/hero-${ this.heroImageIndex }.jpg`)
+    },
+    nextHeroImage () {
+      const nextIndex = this.heroImageIndex + 1 < NUM_HERO_PIX ?
+        this.heroImageIndex + 1
+      : 1
+      return require(`./images/hero-${ nextIndex }.jpg`)
     }
   }, // end 'computed'
 
   /*
    * Instructions to execute when this component mounts on the DOM (i.e. when loaded for user).
    */
-  mounted () {
+  created () {
     // TODO handle errors
     /* Initialize fade-flowing hero images */
     this.intervalId = setInterval(() => {

--- a/src/pages/Home/template.html
+++ b/src/pages/Home/template.html
@@ -6,6 +6,7 @@
     <transition name="v-fade-overlay">
       <img class="hero-img" :src="heroImage" :key="heroImageIndex">
     </transition>
+    <img class="d-none" :src="nextHeroImage">
     <img class="logo" src="./images/logo.png">
   </div><!-- /.hero -->
 


### PR DESCRIPTION
Preload the next hero image invisibly to eliminate the race condition of
an unloaded image when fade transitioning.